### PR TITLE
update from remote master

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        php-version: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     name: PHP ${{ matrix.php-version }}
     steps:
     - uses: actions/checkout@v4
@@ -20,7 +20,7 @@ jobs:
       run: composer validate
     - name: Cache Composer packages
       id: composer-cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: vendor
         key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Limitations:
 This project should not be confused with `JsonSerializable` interface added on PHP 5.4. This interface is used on
 `json_encode` to encode the objects. There is no unserialization with this interface, differently from this project.
 
-*Json Serializer requires PHP >= 7.0 and tested until PHP 8.2*
+*Json Serializer requires PHP >= 7.2 and tested until PHP 8.2*
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Limitations:
 This project should not be confused with `JsonSerializable` interface added on PHP 5.4. This interface is used on
 `json_encode` to encode the objects. There is no unserialization with this interface, differently from this project.
 
-*Json Serializer requires PHP >= 7.2 and tested until PHP 8.2*
+*Json Serializer requires PHP >= 7.2 and tested until PHP 8.4*
 
 ## Example
 

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "opis/closure": "Allow to serialize PHP closures"
     },
     "require-dev": {
-        "phpunit/phpunit": ">=6.0 <11.0"
+        "phpunit/phpunit": ">=8 <12.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": "^7.0 || ^8.0",
+        "php": "^7.2 || ^8.0",
         "ext-mbstring": "*"
     },
     "suggest": {

--- a/src/JsonSerializer/JsonSerializer.php
+++ b/src/JsonSerializer/JsonSerializer.php
@@ -72,11 +72,11 @@ class JsonSerializer
     /**
      * Constructor.
      *
-     * @param ClosureSerializerInterface $closureSerializer This parameter is deprecated and will be removed in 5.0.0. Use addClosureSerializer() instead.
+     * @param ClosureSerializerInterface|null $closureSerializer This parameter is deprecated and will be removed in 5.0.0. Use addClosureSerializer() instead.
      * @param array                      $customObjectSerializerMap
      */
     public function __construct(
-        ClosureSerializerInterface $closureSerializer = null,
+        ?ClosureSerializerInterface $closureSerializer = null,
         $customObjectSerializerMap = []
     ) {
         $this->closureManager = new ClosureSerializer\ClosureSerializerManager();

--- a/tests/JsonSerializerTest.php
+++ b/tests/JsonSerializerTest.php
@@ -26,6 +26,7 @@ class JsonSerializerTest extends TestCase
      * @before
      * @return void
      */
+    #[\PHPUnit\Framework\Attributes\Before]
     public function setUpSerializer()
     {
         $customObjectSerializerMap['Zumba\\JsonSerializer\\Test\\SupportClasses\\MyType'] = new \Zumba\JsonSerializer\Test\SupportClasses\MyTypeSerializer();
@@ -40,6 +41,7 @@ class JsonSerializerTest extends TestCase
      * @param        string $jsoned
      * @return       void
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('scalarData')]
     public function testSerializeScalar($scalar, $jsoned)
     {
         $this->assertSame($jsoned, $this->serializer->serialize($scalar));
@@ -74,6 +76,7 @@ class JsonSerializerTest extends TestCase
      * @param        string $jsoned
      * @return       void
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('scalarData')]
     public function testUnserializeScalar($scalar, $jsoned)
     {
         $this->assertSame($scalar, $this->serializer->unserialize($jsoned));
@@ -134,6 +137,7 @@ class JsonSerializerTest extends TestCase
      * @param        string $jsoned
      * @return       void
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('arrayNoObjectData')]
     public function testSerializeArrayNoObject($array, $jsoned)
     {
         $this->assertSame($jsoned, $this->serializer->serialize($array));
@@ -147,6 +151,7 @@ class JsonSerializerTest extends TestCase
      * @param        string $jsoned
      * @return       void
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('arrayNoObjectData')]
     public function testUnserializeArrayNoObject($array, $jsoned)
     {
         $this->assertSame($array, $this->serializer->unserialize($jsoned));


### PR DESCRIPTION
This pull request includes several changes to update PHP version compatibility, improve code quality, and enhance testing. The most important changes include updating the PHP versions in the workflow, README, and `composer.json` file, modifying the constructor of the `JsonSerializer` class, and adding data providers to PHPUnit tests.

### PHP Version Updates:
* [`.github/workflows/php.yml`](diffhunk://#diff-a73bb6555480a5ee79ae276a3f5d71a08fa316e09a4a8da7b643cf1e92c97df9L15-R23): Updated the PHP versions in the matrix to remove older versions and add PHP 8.4.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L44-R44): Updated the PHP version requirements to indicate support for PHP 7.2 and testing up to PHP 8.4.
* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L22-R29): Updated the PHP version constraints and the `phpunit/phpunit` version range.

### Code Quality Improvements:
* [`src/JsonSerializer/JsonSerializer.php`](diffhunk://#diff-9432a8da8c97f129545958925444cdbd404482c4af19bca674b2c5fac9da7980L75-R79): Modified the constructor to allow `ClosureSerializerInterface` to be nullable.

### Testing Enhancements:
* [`tests/JsonSerializerTest.php`](diffhunk://#diff-c175ecf1ca6ae2f33d054ade3e58977c60b7b0256737033b668b01483906f42cR29): Added data providers to multiple test methods using PHPUnit attributes. [[1]](diffhunk://#diff-c175ecf1ca6ae2f33d054ade3e58977c60b7b0256737033b668b01483906f42cR29) [[2]](diffhunk://#diff-c175ecf1ca6ae2f33d054ade3e58977c60b7b0256737033b668b01483906f42cR44) [[3]](diffhunk://#diff-c175ecf1ca6ae2f33d054ade3e58977c60b7b0256737033b668b01483906f42cR79) [[4]](diffhunk://#diff-c175ecf1ca6ae2f33d054ade3e58977c60b7b0256737033b668b01483906f42cR140) [[5]](diffhunk://#diff-c175ecf1ca6ae2f33d054ade3e58977c60b7b0256737033b668b01483906f42cR154)