### PR TITLE
Cannot access property starting with "\0" in AbstractEvent::getParameters()

### DIFF
--- a/src/JsonSerializer/JsonSerializer.php
+++ b/src/JsonSerializer/JsonSerializer.php
@@ -244,7 +244,15 @@ class JsonSerializer
             $props[] = $prop->getName();
         }
 
-        return array_unique(array_merge($props, array_keys(get_object_vars($value))));
+        return array_unique(
+            array_merge(
+                $props,
+                array_filter(
+                    array_keys(get_object_vars($value)),
+                    static fn(string $key) => !str_starts_with($key, "\0")
+                )
+            )
+        );
     }
 
     /**
@@ -556,6 +564,10 @@ class JsonSerializer
                 $propRef->setAccessible(true);
                 $propRef->setValue($obj, $this->unserializeData($propertyValue));
             } catch (ReflectionException $e) {
+                // Skip null-byte-prefixed properties
+                if (str_starts_with($property, "\0")) {
+                    continue;
+                }
                 switch ($this->undefinedAttributeMode) {
                     case static::UNDECLARED_PROPERTY_MODE_SET:
                         $obj->$property = $this->unserializeData($propertyValue);


### PR DESCRIPTION
This pull request improves the handling of object properties during JSON serialization and deserialization, specifically by filtering out properties with names starting with a null byte (which are typically internal or private properties in PHP). This helps prevent issues related to inaccessible or internal properties during these processes.

**Serialization improvements:**

* In `getObjectProperties`, updated the logic to exclude properties whose names start with a null byte when merging property names, ensuring only accessible properties are included.

**Deserialization improvements:**

* In `unserializeObject`, added a check to skip properties with names starting with a null byte when a `ReflectionException` occurs, preventing attempts to set inaccessible or internal properties.